### PR TITLE
Speed for free!

### DIFF
--- a/ImgStore.rb
+++ b/ImgStore.rb
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 
-require 'chunky_png'
+begin
+	require 'oily_png'
+rescue LoadError
+	require 'chunky_png'
+	puts 'oily_png gem not installed. Using pure chunky_png. This might be slow!'
+end
 
 module ImgStore
 	def ImgStore.encode(data, filename)


### PR DESCRIPTION
oily_png is a c-extension with the same functionality and interface as chunky_png but blazing fast.
In case it's not installed, fall back to pure chunky_png.
I use this in all my ruby/png experiments.

You're welcome :D
